### PR TITLE
fix(cla): forward status to PR head commit

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,11 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'pull_request_target'
+      || github.event_name == 'workflow_call'
       || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
     steps:
       - name: CLA Assistant
+        id: cla-check
         if: >
           github.event_name == 'pull_request_target'
+          || github.event_name == 'workflow_call'
           || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
           || github.event.comment.body == 'recheck'
         uses: contributor-assistant/github-action@v2.6.1
@@ -52,3 +55,25 @@ jobs:
           custom-allsigned-prcomment: "All contributors have signed the CLA."
           lock-pullrequest-aftermerge: "true"
           suggest-recheck: "true"
+
+      # Forward CLA status to the PR head commit. `pull_request_target`
+      # runs against the base branch SHA, so the status the CLA action
+      # posts never lands on the PR head — causing required-check rules
+      # to stay stuck on "expected".
+      - name: Forward CLA status to PR head
+        if: always() && github.event.pull_request.head.sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ steps.cla-check.outcome }}" = "success" ]; then
+            STATE="success"
+            DESC="All contributors have signed the CLA."
+          else
+            STATE="failure"
+            DESC="CLA signature required."
+          fi
+
+          gh api "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -f state="$STATE" \
+            -f context="cla / cla" \
+            -f description="$DESC"


### PR DESCRIPTION
## Summary

- Forward CLA check outcome (success/failure) to the PR head SHA after the CLA action runs
- Add `workflow_call` to job/step `if` conditions for reusable workflow compatibility

## Problem

`pull_request_target` workflows run against the base branch SHA. The CLA action's check run and any status it posts land on that base SHA, not the PR head commit. When an org-level ruleset requires `cla / cla` on the PR head (like the "CLA Required" ruleset), the check stays stuck on "expected" indefinitely.

This affects all repos in the org that use this reusable CLA workflow.

## Fix

A new step runs after the CLA action (`if: always()`) and posts a commit status to `github.event.pull_request.head.sha` with the correct outcome. The `if` guard on `github.event.pull_request.head.sha` ensures it only runs for PR events, not issue comments.

## Test plan

- [ ] Verify on an existing PR (e.g. omnidotdev/rdk#80) that the `cla / cla` check appears on the PR head after merge
- [ ] Confirm unsigned CLA correctly shows failure status on PR head
- [ ] Confirm issue_comment (`recheck` / signing) path still works